### PR TITLE
Add missing peer dependency for `postcss`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "coverage": "c8 report --reporter=lcov",
     "publish": "clean-publish"
   },
+	"peerDependencies": {
+    "postcss": "^8.2",
+  },
   "devDependencies": {
     "ava": "^4.0.1",
     "c8": "^7.10.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "publish": "clean-publish"
   },
   "peerDependencies": {
-    "postcss": "^8.2",
+    "postcss": "^8.2"
   },
   "devDependencies": {
     "ava": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "coverage": "c8 report --reporter=lcov",
     "publish": "clean-publish"
   },
-	"peerDependencies": {
+  "peerDependencies": {
     "postcss": "^8.2",
   },
   "devDependencies": {


### PR DESCRIPTION
see : https://github.com/postcss/postcss/blob/main/docs/guidelines/plugin.md#14-keep-postcss-to-peerdependencies

We test against `postcss` version `8.2` in `postcss-preset-env` so we are sure that this is a safe baseline for the peer dependency.